### PR TITLE
Fix #737 by computing `rec_type` after `adjust_sign_arity` in equations.ml

### DIFF
--- a/src/covering.ml
+++ b/src/covering.ml
@@ -726,7 +726,7 @@ let make_fix_proto env sigma ty =
   let na = make_annot Anonymous r in
   relevance, mkLetIn (na, fixproto, Retyping.get_type_of env sigma fixproto, lift 1 ty)
 
-let compute_fixdecls_data env evd ?data programs =
+let compute_fixdecls_data env sigma ?data programs =
   let protos = List.map (fun p ->
       let ty = it_mkProd_or_LetIn p.program_arity p.program_sign in
       (p.program_id, ty, p.program_impls)) programs
@@ -734,9 +734,9 @@ let compute_fixdecls_data env evd ?data programs =
   let names, tys, impls = List.split3 protos in
   let data =
     Constrintern.compute_internalization_env ?impls:data
-    env !evd Constrintern.Recursive names tys impls
+    env sigma Constrintern.Recursive names tys impls
   in
-  let fixprots = List.map (fun ty -> make_fix_proto env !evd ty) tys in
+  let fixprots = List.map (fun ty -> make_fix_proto env sigma ty) tys in
   let fixdecls =
     List.map2 (fun i (relevance, fixprot) -> of_tuple (make_annot (Name i) relevance, None, fixprot)) names fixprots in
   data, List.rev fixdecls, fixprots
@@ -1553,7 +1553,7 @@ and interp_clause env evars p data prev clauses' path prob
 
 and interp_wheres env0 ctx evars path data s lets
     (ctx, envctx, liftn, subst)
-    (w : (pre_prototype * pre_equation list) list * Vernacexpr.notation_declaration list) =
+    (w : pre_equation wheres) =
   let notations = snd w in
   let aux (data,lets,nlets,coverings,env)
       (((loc,id),udecl,nested,b,t,reca),clauses as eqs) =
@@ -1635,10 +1635,6 @@ and covering ?(check_unused=true) env evars p data (clauses : pre_clause list)
        pr_problem p env !evars prob)
 
 let program_covering env evd data p clauses =
-  let clauses = List.map (interp_eqn (push_rel_context data.fixdecls env) !evd
-    data.notations p ~avoid:Id.Set.empty) clauses in
-  let sigma, p = adjust_sign_arity env !evd p clauses in
-  let () = evd := sigma in
   let p', prob, arity, extpats, rec_node = compute_rec_data env evd data [] [] p in
   let splitting =
     covering env evd p data clauses [p.program_id] prob extpats arity

--- a/src/covering.mli
+++ b/src/covering.mli
@@ -198,7 +198,7 @@ val compute_rec_type : rec_type -> program_info list -> rec_type
 val print_program_info : env -> Evd.evar_map -> program_info list -> unit
 val compute_fixdecls_data :
            Environ.env ->
-           Evd.evar_map ref ->
+           Evd.evar_map ->
            ?data:Constrintern.internalization_env ->
            Syntax.program_info list ->
            Constrintern.internalization_env *
@@ -253,5 +253,5 @@ val coverings :
   Evd.evar_map ref ->
   int_data ->
   Syntax.program_info list ->
-  pre_equation list list ->
+  pre_clause list list ->
   Splitting.program list

--- a/src/equations.ml
+++ b/src/equations.ml
@@ -175,13 +175,22 @@ let define_by_eqs ~pm ~poly ~program_mode ~obligations ~tactic ~open_proof opts 
   let programs = List.map (fun (((loc,i),udecl,rec_annot,l,t,by),clauses as ieqs) ->
       let is_rec = is_recursive i (eqs, nt) in
       interp_arity env evd ~poly ~is_rec ~with_evars:open_proof nt ieqs) eqs in
-  let rec_type = compute_rec_type [] programs in
   let () = print_program_info env !evd programs in
   let env = Global.env () in (* To find the comp constant *)
-  let data, fixdecls, fixprots = compute_fixdecls_data env evd programs in
+  let data, fixdecls, fixprots = compute_fixdecls_data env !evd programs in
   let fixdecls = nf_rel_context_evar !evd fixdecls in
+  let equations =
+    let interp_eqns p clauses =
+      List.map (interp_eqn (push_rel_context fixdecls env) !evd nt p ~avoid:Id.Set.empty) clauses
+    in List.map2 interp_eqns programs (List.map snd eqs)
+  in
+  let programs = List.map2 (fun p clauses ->
+                     let sigma, p = adjust_sign_arity env !evd p clauses in
+                     evd := sigma; p) programs equations
+  in
+  let rec_type = compute_rec_type [] programs in
   let intenv = { rec_type; flags; fixdecls; intenv = data; notations = nt; program_mode } in
-  let programs = coverings env evd intenv programs (List.map snd eqs) in
+  let programs = coverings env evd intenv programs equations in
   let env = Global.env () in (* coverings has the side effect of defining comp_proj constants for now *)
   let fix_proto_ref = Globnames.destConstRef (Lazy.force coq_fix_proto) in
   (* let _kind = (Decl_kinds.Global Decl_kinds.ImportDefaultBehavior, poly, Decl_kinds.Definition) in *)

--- a/test-suite/issues/issue737.v
+++ b/test-suite/issues/issue737.v
@@ -1,0 +1,9 @@
+From Equations Require Import Equations.
+
+
+Equations plus (n : nat) : nat -> nat by wf n lt :=
+  plus 0 m := 0;
+  plus (S k) m :=
+    (* This used to be elaborated into [S (plus k _ m)] instead of [S (plus k m _)],
+       in a context where [plus : forall n : nat, nat -> n < k -> nat] *)
+    S (plus k m).


### PR DESCRIPTION
Fixes #737.

Functions in covering.ml carry around information of type `int_data`. It is computed in part in Equations.define_by_eqs and contains a field `rec_type` which among other things, for well-founded recursive definitions carries the data of the position at which the additional wf recursion argument should be added.  This position is the length of context of the signature of the function to be defined, howerer this signature is sometimes extended when the return type is a product type. The constructed internal type of the function that is used for the fixpoint combinator uses this updated signature, making the computed `rec_type` outdated.

This PR does the following: 
- move the interpretation of `pre_equations` into `pre_clauses` and the call to `adjust_sign_arity` from `Covering.program_covering` to `Equations.define_by_eqs`.
- compute `rec_type` data *after* adjusting the signature and the arity of the program
- minor change: make `compute_fixdecls_data` take an evar_map instead of a reference since it doesn't modify it

There should not be any observable change in behavior apart from the rec_type now being computed with the relevant signature, because the two operations that were moved above were happening right after in `Covering.program_covering` with the same arguments, and `Equations.define_by_eqs` is the only caller of `program_covering`. This is also makes the treatement similar to [the one done for local wheres in `Covering.interp_wheres`](https://github.com/rocq-prover/equations/blob/d562d8c413f4b0d2a837ef742d08fa59d14107e6/src/covering.ml#L1562-L1573) in which rec_type was computed after adjusting the signature.