### PR TITLE
Guard against partial applications of wfrec functions (closes #555, #609)

### DIFF
--- a/src/covering.ml
+++ b/src/covering.ml
@@ -319,10 +319,20 @@ let add_wfrec_implicits rec_type c =
     let rec aux c =
       let maprec a = Glob_ops.map_glob_constr_left_to_right aux a in
       let mapargs ts = List.map aux ts in
+      let err_partial_app fid loc nargs =
+        let open Pp in
+        user_err_loc (loc,
+             str "Partially applied well-founded recursive functions are not supported " ++
+             str "(here, " ++ Names.Id.print fid ++ str " should take " ++ int nargs ++ str " aguments)." ++
+             cut () ++
+             str "Beware: abstracting over arguments occuring in the wf expression " ++
+             str "to make the application total might cause losing information " ++
+             str "that is needed to prove that the recursive call is decreasing.")
+      in
       DAst.with_loc_val (fun ?loc g ->
           match g with
           | GApp (fn, args) ->
-            DAst.with_loc_val (fun ?loc gfn ->
+            DAst.with_loc_val (fun ?loc:_ gfn ->
                 match gfn with
                 | GVar fid -> 
                   (match is_wf_ref fid rec_type with
@@ -332,12 +342,17 @@ let add_wfrec_implicits rec_type c =
                                             qm_name = Anonymous;
                                             qm_record_field = None }
                     in
+                    let () = if List.length args < nargs then err_partial_app fid loc nargs in
                     let newarg = GHole (GQuestionMark kind) in
                     let newarg = DAst.make ?loc newarg in
                     let before, after = List.chop nargs (mapargs args) in
                     let args' = List.append before (newarg :: after) in
                     DAst.make ?loc (GApp (fn, args')))
                 | _ -> maprec c) fn
+          | GVar fid ->
+             (match is_wf_ref fid rec_type with
+             | exception Not_found -> maprec c
+             | nargs -> err_partial_app fid loc nargs)
           | _ -> maprec c) c
     in aux c
   else c


### PR DESCRIPTION
Fixes #555, fixes #609.
The function `Covering.add_wfrec_implicits` adds a hole at the end of every well-founded recursive function call ( corresponding to the proof that the call is decreasing), and does not check if the call has enough arguments.
This PR adds a check that the function is fully applied, and reports an error to the user otherwise.



**PS**
An alternative would be to eta-expand such partial applications inorded to be able to insert the wfrec hole, howerer, this might abstract away information needed for the wfrec proof and result in confusing unsolvable obligations. For example, with this alternative, while it would allow this definition
```rocq
Equations plus (n : nat) (m : nat) : nat by wf n lt :=
  plus 0 m := 0;
  plus (S n) m := S (let plus_n := plus n in plus_n m).
```
to pass, if one tries
```rocq
Equations plus (n : nat) (m : nat) : nat by wf n lt :=
  plus 0 m := 0
  plus (S n) m := S (let plus' := plus in plus' n m
```
it succeeds but leaves an obligation of the form `n0 : nat |- n0 < S n` with no information about `n0`.
A realistic example where this second case occurs is the last definition with manual eta-expansion in #609.